### PR TITLE
Fixes <nolink> and <separator> in breadcrumbs

### DIFF
--- a/special_menu_items.module
+++ b/special_menu_items.module
@@ -307,8 +307,10 @@ function special_menu_items_menu_breadcrumb_alter(&$active_trail) {
   // Loop backwards through the breadcrumbs
   $backward_crumbs = array_reverse($active_trail);
   foreach ($backward_crumbs as $index => $crumb) {
-    if ($crumb['href'] == '<nolink>' || $crumb['href'] == '<separator>' ) {
+    if ($crumb['href'] == '<nolink>') {
       $backward_crumbs[$index]['href'] = $previous_href;
+    } elseif ($crumb['href'] == '<separator>') {
+      unset ($backward_crumbs[$index]);
     } else {
       $previous_href = $crumb['href'];
     }

--- a/special_menu_items.module
+++ b/special_menu_items.module
@@ -296,10 +296,10 @@ function special_menu_items_form_menu_overview_form_alter(&$form, &$form_state, 
 
 /**
  * Implements hook_breadcrumb_alter().
- * This is used to fix the issue of breadcrumbs pointing at <nolink>
+ * This is used to fix the issue of breadcrumbs pointing at <nolink>.
  * 
  * This function finds crumbs with href pointing at <nolink> and replaces them 
- * with the href of the next crumb
+ * with the href of the next crumb.
  */
 function special_menu_items_menu_breadcrumb_alter(&$active_trail) {
   $previous_href = backdrop_get_path_alias();

--- a/special_menu_items.module
+++ b/special_menu_items.module
@@ -296,9 +296,9 @@ function special_menu_items_form_menu_overview_form_alter(&$form, &$form_state, 
 
 /**
  * Implements hook_breadcrumb_alter().
- * This is used to fix the issue of breadcrumbs pointing at <nolink>.
+ * This is used to fix the issue of breadcrumbs pointing at <nolink> or <separator>.
  * 
- * This function finds crumbs with href pointing at <nolink> and replaces them 
+ * This function finds crumbs with href pointing at <nolink> or <separator> and replaces them 
  * with the href of the next crumb.
  */
 function special_menu_items_menu_breadcrumb_alter(&$active_trail) {
@@ -307,7 +307,7 @@ function special_menu_items_menu_breadcrumb_alter(&$active_trail) {
   // Loop backwards through the breadcrumbs
   $backward_crumbs = array_reverse($active_trail);
   foreach ($backward_crumbs as $index => $crumb) {
-    if ($crumb['href'] == '<nolink>') {
+    if ($crumb['href'] == '<nolink>' || $crumb['href'] == '<separator>' ) {
       $backward_crumbs[$index]['href'] = $previous_href;
     } else {
       $previous_href = $crumb['href'];

--- a/special_menu_items.module
+++ b/special_menu_items.module
@@ -65,10 +65,12 @@ function special_menu_items_page_callback() {
 }
 
 /**
- * A replacement for theme_link().
+ * A replacement for theme_menu_link().
  *
  * This function will render a link if it is "nolink" or "separator". Otherwise
  * it will call the original menu item link function.
+ * 
+ * @see special_menu_items_theme_registry_alter().
  */
 function special_menu_items_link($variables) {
   $element = $variables['element'];
@@ -290,4 +292,26 @@ function special_menu_items_form_menu_overview_form_alter(&$form, &$form_state, 
       }
     }
   }
+}
+
+/**
+ * Implements hook_breadcrumb_alter().
+ * This is used to fix the issue of breadcrumbs pointing at <nolink>
+ * 
+ * This function finds crumbs with href pointing at <nolink> and replaces them 
+ * with the href of the next crumb
+ */
+function special_menu_items_menu_breadcrumb_alter(&$active_trail) {
+  $previous_href = backdrop_get_path_alias();
+
+  // Loop backwards through the breadcrumbs
+  $backward_crumbs = array_reverse($active_trail);
+  foreach ($backward_crumbs as $index => $crumb) {
+    if ($crumb['href'] == '<nolink>') {
+      $backward_crumbs[$index]['href'] = $previous_href;
+    } else {
+      $previous_href = $crumb['href'];
+    }
+  }
+  $active_trail = array_reverse($backward_crumbs);
 }


### PR DESCRIPTION
This PR fixes issue #22 - breadcrumbs pointing at href `<nolink>` for special menu items.

There may be other ways to fix this issue. I've chosen to implement `hook_breadcrumb_alter()`, rather than messing with the theming functions. Using theme functions like `theme_breadcrumb()` to solve this issue is problematic, as theme functions can be overridden by custom themes, resulting in a loss of any potential fixes.

I have tested in situations where Special Menu Items have several depths of links below and it seems to be working fine. Please test further.
 