### PR TITLE
Implements a link replacement for Header Block menus

### DIFF
--- a/special_menu_items.module
+++ b/special_menu_items.module
@@ -65,12 +65,14 @@ function special_menu_items_page_callback() {
 }
 
 /**
- * A replacement for theme_link().
+ * A replacement for theme_menu_link().
  *
  * This function will render a link if it is "nolink" or "separator". Otherwise
  * it will call the original menu item link function.
+ * 
+ * @see special_menu_items_theme_registry_alter().
  */
-function special_menu_items_link($variables) {
+function special_menu_items_menu_link($variables) {
   $element = $variables['element'];
   if (in_array($element['#href'], array('<nolink>', '<separator>'))) {
     $attributes = array('class' => array());
@@ -102,8 +104,31 @@ function special_menu_items_link($variables) {
 
   // Call the original theme function for normal menu link.
   $theme_registry = theme_get_registry();
-  $function = $theme_registry['special_menu_items_link_default']['function'];
+  $function = $theme_registry['special_menu_items_menu_link_default']['function'];
   return $function($variables);
+}
+
+/**
+ * A replacement for theme_links().
+ *
+ * This function will replace href pointing at "nolink" or "separator" with the current path. 
+ * It is used for Header Block menus containing Special Menu Items in their
+ * first level.
+ * 
+ * @see special_menu_items_theme_registry_alter().
+ */
+function special_menu_items_links($variables) {
+ $current_page = backdrop_get_path_alias();
+ // Replace href  containing <nolink> or <separator> with current page 
+ foreach ($variables['links'] as &$link) {
+   if (in_array($link['href'], array('<nolink>', '<separator>'))) {
+     $link['href'] = $current_page;
+   }
+ }
+ // Call the original theme function for normal menu link.
+ $theme_registry = theme_get_registry();
+ $function = $theme_registry['special_menu_items_links_default']['function'];
+ return $function($variables);
 }
 
 /**
@@ -128,13 +153,17 @@ function special_menu_items_render_menu_item($tag, $value, $attributes = array()
 /**
  * Implements hook_theme_registry_alter().
  *
- * We replace theme_menu_item_link with our own function.
+ * We replace theme_menu_link and theme_links with our own functions.
  */
 function special_menu_items_theme_registry_alter(&$registry) {
   // Save previous value from registry in case another theme overwrites 
   // menu_item_link.
-  $registry['special_menu_items_link_default'] = $registry['menu_link'];
-  $registry['menu_link']['function'] = 'special_menu_items_link';
+  $registry['special_menu_items_menu_link_default'] = $registry['menu_link'];
+  $registry['menu_link']['function'] = 'special_menu_items_menu_link';
+
+  // Save previous value of registry's links function in case a another theme overwrites 
+  $registry['special_menu_items_links_default'] = $registry['links'];
+  $registry['links']['function'] = 'special_menu_items_links';
 }
 
 /**


### PR DESCRIPTION
This PR is one possible way to solve issue #21. In that issue, Special Menu Items in **Header block menus** incorrectly pointed to `</nolink>`. 

This patch basically does the following:
- In the theme registry, it overwrites the function called for `theme_links`, which is called to theme the links of Header block menus
-  The replacement function loops through the links in $variable to find any href pointing at `<nolink>` or `<separator>`, and it replaces those with the current path
- The replacement function then calls the original function for `theme_links`

Please note: the Special Menu Items in the Header block menu will now point at the current path. Since Special Menu Items don't really have a real href, this is a compromise solution. This means that, when the user clicks on the Special Menu Item in the menu, the current page will be reloaded. 

As you may have guessed, it's not a good idea to use menus containing Special Menu Items in the Header Block menu. Those menus are always shown as "1st level" menus, rather than dropdowns. Thus the Special Menu Items serve no function. So, this patch is just a cosmetic solution to avoid showing links to inexistent "nolink" href and avoiding 404s.

Please comment, modify or feel free to ignore this patch, as it really doesn't serve any purpose other than avoiding a 404.